### PR TITLE
Use iter for memory efficiency

### DIFF
--- a/flowfast/step.py
+++ b/flowfast/step.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
-from typing import Any, Callable, Dict, Iterable, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
-from flowfast.base import Step, WorkflowBase
+from flowfast.base import Step
 
 Mapping = Dict[str, Any]
 Predicate = Callable[[Mapping], bool]

--- a/flowfast/workflow.py
+++ b/flowfast/workflow.py
@@ -31,9 +31,7 @@ class Workflow(WorkflowBase[I, O]):
     @classmethod
     def for_each(cls, wf: WorkflowBase[I, O]) -> WorkflowBase[Iterable[I], Iterable[O]]:
         def _execute_all(inputs: Iterable[I]):
-            results = []
             for input in inputs:
-                results.append(wf.run(input))
-            return results
+                yield wf.run(input)
 
         return Workflow[Iterable[I], Iterable[O]](_StepConnector(_execute_all))

--- a/tests/test_wokflow.py
+++ b/tests/test_wokflow.py
@@ -53,4 +53,4 @@ def test_iterable_input_flow():
     expected = [2, 1, 5]
 
     actual = tested.run([1, 0, 4])
-    assert actual == expected
+    assert list(actual) == expected


### PR DESCRIPTION
- Changed the iter workflow to use yied instead list append. This will make the pattern memory efficient